### PR TITLE
NATS headers without parsing as JSON, and support Flush

### DIFF
--- a/NLog.Nats.Example/NLogNatsExample/NLog.config
+++ b/NLog.Nats.Example/NLogNatsExample/NLog.config
@@ -7,7 +7,8 @@
   </extensions>
 
   <targets>
-    <target xsi:type="Nats" name="nats" NatsUrl="nats://localhost:4222" Subject="logs" headers='{"Custom_Header":"Custom Header Value"}'>
+    <target xsi:type="Nats" name="nats" NatsUrl="nats://localhost:4222" Subject="logs" SingleParameter="true">
+      <header name="Custom_Header" layout="Custom Header Value" />
       <layout>${longdate} ${level} || ${level} || ${message} ${exception}</layout>
     </target>
     <target xsi:type="File" name="file" fileName="logs.txt" layout="${longdate} ${level} ${message} ${exception}" />

--- a/NLog.Nats.Example/NLogNatsExample/NLogNatsExample.csproj
+++ b/NLog.Nats.Example/NLogNatsExample/NLogNatsExample.csproj
@@ -13,9 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="NLog.Targets.Nats">
-      <HintPath>..\..\NLog.Targets.Nats\bin\Release\net8.0\NLog.Targets.Nats.dll</HintPath>
-    </Reference>
+    <ProjectReference Include="..\..\NLog.Targets.Nats\NLog.Targets.Nats.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/NLog.Targets.Nats/NLog.Targets.Nats.cs
+++ b/NLog.Targets.Nats/NLog.Targets.Nats.cs
@@ -9,28 +9,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using NATS;
 using NATS.Client.Core;
 using NATS.Client.Serializers.Json;
-using NLog;
 using NLog.Common;
 using NLog.Config;
 using NLog.Layouts;
-using System.Text;
-using System.Text.Json;
 
 namespace NLog.Targets.Nats
 {
     [Target("Nats")]
-    public class NatsTarget : TargetWithLayout
+    public class NatsTarget : TargetWithContext
     {
-        private NatsConnection _natsConnection; 
+        private NatsConnection? _natsConnection;
+        private NatsHeaders? _natsHeaders;
+        private Task _lastWrite = Task.CompletedTask;
 
         [RequiredParameter]
         public Layout NatsUrl { get; set; } = new SimpleLayout(string.Empty);
+
         [RequiredParameter]
         public Layout Subject { get; set; } = new SimpleLayout(string.Empty);
-        public Layout Headers { get; set; } = new SimpleLayout("{}");
+
+        [ArrayParameter(typeof(TargetPropertyWithContext), "header")]
+        public IList<TargetPropertyWithContext> Headers { get; } = new List<TargetPropertyWithContext>();
+
+        public bool SingleParameter { get; set; }
 
         protected override void InitializeTarget()
         {
@@ -44,103 +47,86 @@ namespace NLog.Targets.Nats
             {
                 var options = new NatsOpts { Url = natsUrl };
                 _natsConnection = new NatsConnection(options);
-                _natsConnection.ConnectAsync();
+                ConnectAsyncToNats();
                 InternalLogger.Info("NATS connection successfully initialized.");
             }
             catch (Exception ex)
             {
                 InternalLogger.Error(ex, "Failed to initialize NATS connection.");
             }
+
+            NatsHeaders? headers = new NatsHeaders();
+            foreach (var header in Headers)
+            {
+                var headerValue = header.Layout?.Render(LogEventInfo.CreateNullEvent());
+                if (string.IsNullOrWhiteSpace(header.Name) || string.IsNullOrWhiteSpace(headerValue))
+                {
+                    InternalLogger.Warn("Ignoring NATS header with empty key or value: {0}={1}", header.Name, headerValue);
+                    continue;
+                }
+
+                headers[header.Name] = headerValue;
+            }
+
+            _natsHeaders = headers.Count > 0 ? headers : null;
+        }
+
+        private async Task ConnectAsyncToNats()
+        {
+            try
+            {
+                await (_natsConnection?.ConnectAsync() ?? ValueTask.CompletedTask).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                InternalLogger.Error(ex, "Failed to connect to NATS.");
+            }
         }
 
         protected override void Write(LogEventInfo logEvent)
         {
-            InternalLogger.Info("Entering Write method.");
-
             var subject = this.RenderLogEvent(Subject, logEvent);
-            var headersJson = this.RenderLogEvent(Headers, logEvent);
             var logMessage = this.RenderLogEvent(Layout, logEvent);
 
             // Check if the logEvent has an object to send
-            var message = logEvent.Parameters?.Length > 0 ? logEvent.Parameters[0] : logEvent.Message;
-            try
+            if (SingleParameter && logEvent.Parameters?.Length == 1 && logEvent.Message?.StartsWith('{') == true && logEvent.Message?.EndsWith('}') == true)
             {
-                SendMessageAsync(message, subject, headersJson).Wait();
-                InternalLogger.Info("SendMessageAsync completed successfully.");
+                _lastWrite = SendMessageAsync(logEvent.Parameters[0], subject);
             }
-            catch (Exception ex)
+            else
             {
-                InternalLogger.Error(ex, "Failed to send message.");
+                _lastWrite = SendMessageAsync(logMessage, subject);
             }
         }
 
-        private async Task SendMessageAsync<T>(T message, string subject, string headersJson)
+        private async Task SendMessageAsync<T>(T message, string subject)
         {
-            InternalLogger.Info("Publishing message via NatsJsonSerializer<T>.");
             try
             {
-                NatsHeaders headers = ParseHeaders(headersJson);
-                var serializer = new NatsJsonSerializer<T>();
-                await _natsConnection.PublishAsync(subject: subject, headers: headers, data: message, serializer: serializer).ConfigureAwait(false);
-                InternalLogger.Info("Message published successfully.");
+                var serializer = NatsJsonSerializerFactory<T>.Default;
+                await (_natsConnection?.PublishAsync(subject: subject, headers: _natsHeaders, data: message, serializer: serializer) ?? ValueTask.CompletedTask).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
-                InternalLogger.Error(ex, "Failed to publish message.");
+                InternalLogger.Error(ex, "Failed to publish message to NATS.");
             }
         }
-        private NatsHeaders ParseHeaders(string headersJson)
+
+        protected override void FlushAsync(AsyncContinuation asyncContinuation)
         {
-            var headers = new NatsHeaders();
-
-            if (string.IsNullOrWhiteSpace(headersJson))
-            {
-                InternalLogger.Warn("Headers JSON is empty or whitespace. Using empty headers.");
-                return headers;
-            }
-
-            try
-            {
-                // Parse JSON into a dictionary
-                var parsedHeaders = JsonSerializer.Deserialize<Dictionary<string, string>>(headersJson, new JsonSerializerOptions
-                {
-                    PropertyNameCaseInsensitive = true // Handle case-insensitive keys if necessary
-                });
-
-                if (parsedHeaders != null)
-                {
-                    foreach (var kvp in parsedHeaders)
-                    {
-                        if (string.IsNullOrWhiteSpace(kvp.Key) || string.IsNullOrWhiteSpace(kvp.Value))
-                        {
-                            InternalLogger.Warn("Ignoring header with empty key or value: {0}:{1}", kvp.Key, kvp.Value);
-                            continue;
-                        }
-                        headers[kvp.Key] = kvp.Value;
-                    }
-                }
-                else
-                {
-                    InternalLogger.Warn("Parsed headers are null. Using empty headers.");
-                }
-            }
-            catch (JsonException ex)
-            {
-                InternalLogger.Error(ex, "Failed to parse headers JSON. Ensure valid JSON format. Headers JSON: {0}", headersJson);
-            }
-            catch (Exception ex)
-            {
-                InternalLogger.Error(ex, "Unexpected error occurred while parsing headers JSON: {0}", headersJson);
-            }
-
-            return headers;
+            _lastWrite.ContinueWith(t => asyncContinuation(t.Exception));
         }
 
         protected override void CloseTarget()
         {
-            _natsConnection?.DisposeAsync().AsTask().Wait();
+            _natsConnection?.DisposeAsync().AsTask().GetAwaiter().GetResult();
             base.CloseTarget();
             InternalLogger.Info("NATS connection closed.");
+        }
+
+        private static class NatsJsonSerializerFactory<T>
+        {
+            static public readonly NatsJsonSerializer<T> Default = new NatsJsonSerializer<T>();
         }
     }
 }

--- a/NLog.Targets.Nats/NLog.Targets.Nats.sln
+++ b/NLog.Targets.Nats/NLog.Targets.Nats.sln
@@ -3,7 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.10.34928.147
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NLog.Targets.Nats", "NLog.Targets.Nats.csproj", "{B0F0F4F4-81F8-44A7-B1A8-7BE2833C892B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NLog.Targets.Nats", "NLog.Targets.Nats.csproj", "{B0F0F4F4-81F8-44A7-B1A8-7BE2833C892B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NLogNatsExample", "..\NLog.Nats.Example\NLogNatsExample\NLogNatsExample.csproj", "{764E08FF-3A84-4EBC-8C27-FC205F73C2A2}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +17,10 @@ Global
 		{B0F0F4F4-81F8-44A7-B1A8-7BE2833C892B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B0F0F4F4-81F8-44A7-B1A8-7BE2833C892B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B0F0F4F4-81F8-44A7-B1A8-7BE2833C892B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{764E08FF-3A84-4EBC-8C27-FC205F73C2A2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{764E08FF-3A84-4EBC-8C27-FC205F73C2A2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{764E08FF-3A84-4EBC-8C27-FC205F73C2A2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{764E08FF-3A84-4EBC-8C27-FC205F73C2A2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ NLog custom target for NATS messaging server
 | `NatsUrl` | URL for the Nats Connecttion |
 | `Subject` | Subject for the Nats message |
 | `Layout`  | Payload for the Nats message |
-| `Headers` | Custom headers for the Nats message |
+| `SingleParameter` | LogEvent with single parameter, should use parameter value as Payload |
+| `Header`  | Custom headers for the Nats message (Multiple allowed) |
 
 # Example NLog.config file
 ```xml
@@ -20,25 +21,7 @@ NLog custom target for NATS messaging server
 	<targets>
 		<target type="Nats" name="nats" NatsUrl="nats://localhost:4222" Subject="logs">
 			<layout>${longdate} ${level} ${message} ${exception}</layout>
-		</target>
-	</targets>
-
-	<rules>
-		<logger name="*" minlevel="Info" writeTo="nats" />
-	</rules>
-</nlog>
-```
-
-# Example NLog.config file with custom nats header
-```xml
-<nlog>
-	<extensions>
-		<add assembly="NLog.Targets.Nats" />
-	</extensions>
-
-	<targets>
-		<target xsi:type="Nats" name="nats" NatsUrl="nats://localhost:4222" Subject="logs" headers='{"Custom_Header":"Custom Header Value"}'>
-		  <layout>${longdate} ${level} || ${level} || ${message} ${exception}</layout>
+			<header name="My_Custom_Header" layout="Custom Header Value" />	<!-- Multiple allowed -->
 		</target>
 	</targets>
 


### PR DESCRIPTION
One must explicitly specify `SingleParameter = true` to support sending first LogEvent-Parameter-Value as Nats-Message-Payload.

Thus it becomes a non-breaking change when coming from `1.0.0` / `1.0.1` / `1.0.2`