### PR TITLE
Changed back to simple TargetWithLayout

### DIFF
--- a/NLog.Targets.Nats/NLog.Targets.Nats.cs
+++ b/NLog.Targets.Nats/NLog.Targets.Nats.cs
@@ -18,7 +18,7 @@ using NLog.Layouts;
 namespace NLog.Targets.Nats
 {
     [Target("Nats")]
-    public class NatsTarget : TargetWithContext
+    public class NatsTarget : TargetWithLayout
     {
         private NatsConnection? _natsConnection;
         private NatsHeaders? _natsHeaders;


### PR DESCRIPTION
Revert unwanted change introduced with #3 (There is currently no need for TargetWithContext)